### PR TITLE
#12 - DB 접근 로직 구현

### DIFF
--- a/src/main/java/project/board/domain/ArticleComment.java
+++ b/src/main/java/project/board/domain/ArticleComment.java
@@ -26,11 +26,11 @@ public class ArticleComment extends BaseEntity{
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(optional = false)
-    private Article article;
-
     @Column(nullable = false, length = 500)
     private String content;
+
+    @ManyToOne(optional = false)
+    private Article article;
 
     protected ArticleComment() {}
 

--- a/src/main/java/project/board/domain/BaseEntity.java
+++ b/src/main/java/project/board/domain/BaseEntity.java
@@ -6,6 +6,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
@@ -17,14 +18,16 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
-    @Column(nullable = false)
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @CreatedBy
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, length = 100, updatable = false)
     private String createdBy;
 
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
     @Column(nullable = true)
     private LocalDateTime updatedAt;


### PR DESCRIPTION
1. BaseEntity에 @DatetimeFormat, updatable 속성 추가
2. ArticleComment에서 Article 필드와 content 필드의 순서 변경(연관관계 필드를 맨 밑으로)

This closes #12 