### PR TITLE
#19-유저도메인 설계하기

### DIFF
--- a/src/main/java/project/board/domain/UserAccount.java
+++ b/src/main/java/project/board/domain/UserAccount.java
@@ -1,0 +1,60 @@
+package project.board.domain;
+
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Objects;
+
+@Entity
+@Table(name = "user_account")
+public class UserAccount extends BaseEntity {
+
+    @Id
+    @Column(length = 50, nullable = false)
+    private String userId;
+
+    @Setter
+    @Column(nullable = false)
+    private String userPassword;
+
+    @Setter
+    @Column(length = 100)
+    private String email;
+
+    @Setter
+    @Column(length = 100)
+    private String nickname;
+
+    @Setter
+    private String memo;
+
+    protected UserAccount() {}
+
+    private UserAccount(String userId, String userPassword, String email, String nickname, String memo) {
+        this.userId = userId;
+        this.userPassword = userPassword;
+        this.email = email;
+        this.nickname = nickname;
+        this.memo = memo;
+    }
+
+    public static UserAccount of(String userId, String userPassword, String email, String nickname, String memo) {
+        return new UserAccount(userId, userPassword, email, nickname, memo);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserAccount that)) return false;
+        return Objects.equals(userId, that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId);
+    }
+
+}

--- a/src/main/java/project/board/domain/UserAccount.java
+++ b/src/main/java/project/board/domain/UserAccount.java
@@ -1,15 +1,25 @@
 package project.board.domain;
 
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.Table;
 import java.util.Objects;
 
+@Getter
 @Entity
-@Table(name = "user_account")
+@Table(
+    name = "user_account",
+    indexes = {
+        @Index(columnList = "email", unique = true),
+        @Index(columnList = "createdAt"),
+        @Index(columnList = "createdBy")
+    }
+)
 public class UserAccount extends BaseEntity {
 
     @Id


### PR DESCRIPTION
유저도메인을 설게했다. 동등성을 위해서 userId만 필요하므로
equals and hashcode 대상은 userId 만 적용했다.