### PR TITLE
게시판 검색 기능 구현

### DIFF
--- a/src/main/java/project/board/controller/ArticleController.java
+++ b/src/main/java/project/board/controller/ArticleController.java
@@ -39,6 +39,7 @@ public class ArticleController {
 
         map.addAttribute("articles", articles);
         map.addAttribute("paginationBarNumbers", barNumbers);
+        map.addAttribute("searchTypes", SearchType.values());
 
         return "articles/index";
     }

--- a/src/main/java/project/board/domain/type/SearchType.java
+++ b/src/main/java/project/board/domain/type/SearchType.java
@@ -1,5 +1,17 @@
 package project.board.domain.type;
 
+import lombok.Getter;
+
 public enum SearchType {
-    TITLE, CONTENT, ID, NICKNAME, HASHTAG
+    TITLE("제목"),
+    CONTENT("본문"),
+    ID("유저 ID"),
+    NICKNAME("닉네임"),
+    HASHTAG("해시태그");
+
+    @Getter private final String description;
+
+    SearchType(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -22,14 +22,14 @@
             <div class="row">
                 <div class="card card-margin search-form">
                     <div class="card-body p-0">
-                        <form id="search-form">
+                        <form action="/articles" method="get">
                             <div class="row">
                                 <div class="col-12">
                                     <div class="row no-gutters">
                                         <div class="col-lg-3 col-md-3 col-sm-12 p-0">
-                                            <label for="select-type" hidden>유형</label>
-                                            <select class="form-control" id="select-type" name="selectType">
-                                                <option value="title">제목</option>
+                                            <label for="search-type" hidden>유형</label>
+                                            <select class="form-control" id="search-type" name="searchType">
+                                                <option value="title">제목1</option>
                                                 <option value="content">본문</option>
                                                 <option value="id">작성자</option>
                                                 <option value="nickname">닉네임</option>
@@ -37,8 +37,8 @@
                                             </select>
                                         </div>
                                         <div class="col-lg-8 col-md-6 col-sm-12 p-0">
-                                            <label for="select-value" hidden>검색어</label>
-                                            <input type="text" placeholder="Search..." class="form-control" id="select-value" name="select-value">
+                                            <label for="search-value" hidden>검색어</label>
+                                            <input type="text" placeholder="Search..." class="form-control" id="search-value" name="searchValue">
                                         </div>
                                         <div class="col-lg-1 col-md-3 col-sm-12 p-0">
                                             <button type="submit" class="btn btn-base">

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -4,23 +4,41 @@
     <attr sel="#footer" th:replace="component/footer :: footer"/>
 
     <attr sel="main" th:object="${articles}">
+        <attr sel="#search-type" th:remove="all-but-first">
+            <attr sel="option[0]"
+                  th:each="searchType : ${searchTypes}"
+                  th:value="${searchType.name}"
+                  th:text="${searchType.description}"
+                  th:selected="${param.searchType != null && (param.searchType.toString == searchType.name)}">
+            </attr>
+        </attr>
+        <attr sel="#search-value" th:value="${param.searchValue}"/>
+
         <attr sel="#article-table">
             <attr sel="thead/tr">
                 <attr sel="th.title/a" th:text="'제목'" th:href="@{/articles(
                     page=${articles.number},
-                    sort='title' + (*{sort.getOrderFor('title')} != null ? (*{sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : '')
+                    sort='title' + (*{sort.getOrderFor('title')} != null ? (*{sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : ''),
+                    searchType=${param.searchType},
+                    searchValue=${param.searchValue}
                     )}"/>
                 <attr sel="th.hashtag/a" th:text="'해시테그'" th:href="@{/articles(
                     page=${articles.number},
-                    sort='hashtag' + (*{sort.getOrderFor('hashtag')} != null ? (*{sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : '')
+                    sort='hashtag' + (*{sort.getOrderFor('hashtag')} != null ? (*{sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : ''),
+                    searchType=${param.searchType},
+                    searchValue=${param.searchValue}
                     )}"/>
                 <attr sel="th.user-id/a" th:text="'작성자'" th:href="@{/articles(
                     page=${articles.number},
-                    sort='userAccount.userId' + (*{sort.getOrderFor('userAccount.userId')} != null ? (*{sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : '')
+                    sort='userAccount.userId' + (*{sort.getOrderFor('userAccount.userId')} != null ? (*{sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : ''),
+                    searchType=${param.searchType},
+                    searchValue=${param.searchValue}
                     )}"/>
                 <attr sel="th.created-at/a" th:text="'작성일'" th:href="@{/articles(
                     page=${articles.number},
-                    sort='createdAt' + (*{sort.getOrderFor('createdAt')} != null ? (*{sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : '')
+                    sort='createdAt' + (*{sort.getOrderFor('createdAt')} != null ? (*{sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : ''),
+                    searchType=${param.searchType},
+                    searchValue=${param.searchValue}
                     )}"/>
 
             </attr>
@@ -37,20 +55,20 @@
         <attr sel="#pagination">
             <attr sel="li[0]/a"
                   th:text="Previous"
-                  th:href="@{/articles(page=${articles.number - 1})}"
+                  th:href="@{/articles(page=${articles.number - 1}, searchType=${param.searchType}, searchValue=${param.searchValue}, sort=${param.sort})}"
                   th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"/>
 
             <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
                 <attr sel="a"
                       th:text="${pageNumber + 1}"
-                      th:href="@{/articles(page=${pageNumber})}"
+                      th:href="@{/articles(page=${pageNumber}, searchType=${param.searchType}, searchValue=${param.searchValue}, sort=${param.sort})}"
                       th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
                 />
             </attr>
 
             <attr sel="li[2]/a"
                   th:text="Next"
-                  th:href="@{/articles(page=${articles.number + 1})}"
+                  th:href="@{/articles(page=${articles.number + 1}, searchType=${param.searchType}, searchValue=${param.searchValue}, sort=${param.sort})}"
                   th:class="'page-link' + (${articles.number} >=  ${articles.totalPages - 1} ? ' disabled' : '')"
             />
         </attr>

--- a/src/test/java/project/board/controller/ArticleControllerTest.java
+++ b/src/test/java/project/board/controller/ArticleControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import project.board.configuration.SecurityConfiguration;
+import project.board.domain.type.SearchType;
 import project.board.service.ArticleService;
 import project.board.service.PaginationService;
 
@@ -61,6 +62,30 @@ class ArticleControllerTest {
             .andExpect(model().attributeExists("articles"))
             .andExpect(model().attributeExists("paginationBarNumbers"));
         then(articleService).should().searchArticles(eq(null), eq(null), any(Pageable.class));
+        then(paginationService).should().getPaginationBarNumber(anyInt(), anyInt());
+    }
+
+    @DisplayName("[view][GET] 게시판 페이지 - 검색어와 함께 호출")
+    @Test
+    public void givenSearchKeyword_whenSearchingArticlesView_thenReturnsArticlesView() throws Exception {
+        // given
+        SearchType searchType = SearchType.TITLE;
+        String searchValue = "title";
+        given(articleService.searchArticles(eq(searchType), eq(searchValue), any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumber(anyInt(), anyInt())).willReturn(List.of(0, 1, 2, 3, 4));
+
+        // when & then
+        mvc.perform(get("/articles")
+                        .queryParam("searchType", searchType.name() )
+                        .queryParam("searchValue", searchValue)
+
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+            .andExpect(view().name("articles/index"))
+            .andExpect(model().attributeExists("articles"))
+            .andExpect(model().attributeExists("searchTypes"));
+        then(articleService).should().searchArticles(eq(searchType), eq(searchValue), any(Pageable.class));
         then(paginationService).should().getPaginationBarNumber(anyInt(), anyInt());
     }
 


### PR DESCRIPTION
게시판에서의 검색 기능을 추가하였다.
검색 키워드는 `제목`, `본문`, `유저 ID`, `닉네임`, `해시태그` 로 서버에서 뿌려주도록 구현됬다.
이 외의 기존의 정렬, 페이징에서도 검색기능이 적용되도록 param을 추가하였다.

This closes #36 